### PR TITLE
allow installing an import method if existing import is from UNIVERSAL

### DIFF
--- a/lib/Test/Kit.pm
+++ b/lib/Test/Kit.pm
@@ -237,7 +237,9 @@ sub _check_target_does_not_import {
     my $class = shift;
     my $target = shift;
 
-    if ($target->can('import')) {
+    my $import = $target->can('import');
+    my $uniimport = UNIVERSAL->can('import');
+    if ($import && !($uniimport && $import == $uniimport)) {
         die "Package $target already has an import() sub";
     }
 


### PR DESCRIPTION
If the UNIVERSAL.pm module is loaded, or on newer versions of perl, modules may inherit an import method from UNIVERSAL that does nothing. Detect this, and allow overwriting it.